### PR TITLE
fix descriptor to handle older Txid type as new OipRef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/*
+coverage
 .DS_Store
 .idea
 src/components/AudioViewer/scratch.js

--- a/src/builders/decodeDescriptor.js
+++ b/src/builders/decodeDescriptor.js
@@ -51,7 +51,7 @@ export default function decodeDescriptor(protoDescriptor, forWeb = false) {
 
     //creates the field object in webFmt
     for (let field of fieldArray) {
-
+      
       // checks type
       // if type matches enum name
       // add enumRefname to the field object
@@ -74,6 +74,14 @@ export default function decodeDescriptor(protoDescriptor, forWeb = false) {
         case 'sfixed64':
           webFmt.fields[field.name] = {
             type: field.type,
+            id: field.id,
+            repeated: field.repeated,
+            extend: field.extend
+          };
+          break
+        case 'Txid':
+          webFmt.fields[field.name] = {
+            type: 'OipRef',
             id: field.id,
             repeated: field.repeated,
             extend: field.extend

--- a/tests/builders.decodeDescriptor.test.js
+++ b/tests/builders.decodeDescriptor.test.js
@@ -1,0 +1,31 @@
+import decodeDescriptor from '../src/builders/decodeDescriptor'
+
+
+
+describe('Test builder/helper functions', () => {
+  describe('descriptor', () => {
+    it('decode descriptor for web', () => {
+      const expected = {
+        enums: {},
+        fields: {
+          avatar: {
+            type: 'OipRef',
+            id: 1,
+            repeated: false,
+            extend: undefined
+          },
+          urlLinkList: {
+            type: 'OipRef',
+            id: 2,
+            repeated: true,
+            extend: undefined
+          },
+          tagList: { type: 'string', id: 3, repeated: true, extend: undefined }
+        }
+      }
+      const fileDescriptor = 'CoEBCgdwLnByb3RvEhJvaXBQcm90by50ZW1wbGF0ZXMiWgoBUBIUCgZhdmF0YXIYASABKAsyBFR4aWQSGQoLdXJsTGlua0xpc3QYAiADKAsyBFR4aWQSDwoHdGFnTGlzdBgDIAMoCRoTCgRUeGlkEgsKA3JhdxgBIAEoDGIGcHJvdG8z'
+      const { webFmt } = decodeDescriptor(fileDescriptor, true)
+      expect(webFmt).toEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
* add coverage to `.gitinore`
* add support to deprecated `Txid` type of record field
* add test for it